### PR TITLE
Ensure `/ptal` refresh edit function is awaited

### DIFF
--- a/src/commands/ptal.ts
+++ b/src/commands/ptal.ts
@@ -365,7 +365,8 @@ export default {
 			const deferred = await interaction.deferReply({ ephemeral: true });
 			const reply = await generateReplyFromInteraction(description, githubButton.url!, otherButton.url, urls.join(","), interaction);
 			if(!reply) return;
-			interaction.message.edit({ content: reply.content, embeds: reply.embeds, components: reply.components });
+			
+			await interaction.message.edit({ content: reply.content, embeds: reply.embeds, components: reply.components });
 			await deferred.delete();
 		}
 	}


### PR DESCRIPTION
This will hopefully fix the `/ptal` refresh button. Hard to test since this worked okay locally but doesn't work in production, but the fact that the deferred message is properly deleted suggests that the refresh function is completed but disposed before the `edit` transaction can finish.

So... let's try it!