### PR TITLE
fix(ptal): ignore github-actions[bot] reviews

### DIFF
--- a/src/commands/ptal.ts
+++ b/src/commands/ptal.ts
@@ -66,7 +66,9 @@ function GetHumanStatusFromPullRequestState(state: PullRequestState): string
 function GetReviewStateFromReview(state: string): PullRequestState
 {
 	switch (state) {
-		case "COMMENTED": return 'REVIEWED'
+		case "COMMENTED":
+		case "DISMISSED": 
+			return 'REVIEWED'
 		case "CHANGES_REQUESTED": return 'CHANGES_REQUESTED'
 		case "APPROVED": return 'APPROVED'
 		default: {

--- a/src/commands/ptal.ts
+++ b/src/commands/ptal.ts
@@ -156,8 +156,8 @@ const generateReplyFromInteraction = async (description: string, github: string,
 				for (let { state: rawState, user, html_url } of reviews) {
 					const id = user?.login;
 					if (!id) continue;
-					// Filter out reviews from the author, they are always just replies.
-					if (id === pr.data.user.login) {
+					// Filter out reviews from the author and GitHub Actions, they aren't relevant
+					if (id === pr.data.user.login || id === 'github-actions[bot]') {
 						continue;
 					}
 					const current = reviewsByUser.get(id);


### PR DESCRIPTION
- Ignore reviews from `github-actions[bot]`
- Ensure that `DISMISSED` reviews are handled. Just reverts back to the default reviewed state.